### PR TITLE
Fixed path to htpasswd for icinga2-classicui 2.2.4-1~debmon70+1 (Wheezy)

### DIFF
--- a/icinga2-ansible-add-hosts/tasks/icinga2_add_hosts.yml
+++ b/icinga2-ansible-add-hosts/tasks/icinga2_add_hosts.yml
@@ -1,4 +1,6 @@
 ---
+- name: "Create {{ icinga2_hosts_dir }}"
+  file: path={{ icinga2_hosts_dir }} state=directory
 - name: Copy Host Definitions
   template: src=hosts_template.j2
             dest={{ icinga2_hosts_dir }}/{{ hostvars[item]['ansible_fqdn'] }}.conf

--- a/icinga2-ansible-add-hosts/templates/object_logic.j2
+++ b/icinga2-ansible-add-hosts/templates/object_logic.j2
@@ -17,6 +17,14 @@ object Host "{{ hostvars[item]['ansible_fqdn'] }}" {
     {{ entrykey }} = "{{ entryvalue }}"
 {% endfor %}
   } 
+{% set defaults = (value | difference(i)) %}
+{% for j in defaults  %}
+  {{ key }}["{{ j }}"] = { 
+{% for entrykey,entryvalue in value[j].items() %}
+    {{ entrykey }} = "{{ entryvalue }}"
+{% endfor %}
+  } 
+{% endfor %}
 {% endfor %}
 {% else %}
   {{ key }} = "{{ i }}"

--- a/icinga2-ansible-add-hosts/templates/object_logic.j2
+++ b/icinga2-ansible-add-hosts/templates/object_logic.j2
@@ -9,10 +9,19 @@ object Host "{{ hostvars[item]['ansible_fqdn'] }}" {
   # Here Goes Vars and check_command
 {% for key,value in host_attributes.iteritems() %}
 {% for key,value in value.items() %}
+{% if value is mapping %}
+{% for dictname,dictentries in value.items() %}
+  {{ key }}["{{ dictname }}"] = { 
+{% for entrykey,entryvalue in dictentries.items() %}
+    {{ entrykey }} = "{{ entryvalue }}"
+{% endfor %}
+  } 
+{% endfor %}
+{% else %}
   {{ key }} = "{{ value }}"
+{% endif %}
 {% endfor %}
 {% endfor %}
-
 }
 
   #Here Goes Checks if Any

--- a/icinga2-ansible-add-hosts/templates/object_logic.j2
+++ b/icinga2-ansible-add-hosts/templates/object_logic.j2
@@ -8,9 +8,10 @@ object Host "{{ hostvars[item]['ansible_fqdn'] }}" {
 
   # Here Goes Vars and check_command
 {% for key,value in host_attributes.iteritems() %}
-{% for key,value in value.items() %}
-{% if value is mapping %}
-{% for dictname,dictentries in value.items() %}
+{% for key,value in value.items() -%} 
+{% set i = (hostvars[item][key | regex_replace('^vars\.','')]|default(value)) %}
+{% if i is mapping %}
+{% for dictname,dictentries in i.items() %}
   {{ key }}["{{ dictname }}"] = { 
 {% for entrykey,entryvalue in dictentries.items() %}
     {{ entrykey }} = "{{ entryvalue }}"
@@ -18,9 +19,9 @@ object Host "{{ hostvars[item]['ansible_fqdn'] }}" {
   } 
 {% endfor %}
 {% else %}
-  {{ key }} = "{{ value }}"
+  {{ key }} = "{{ i }}"
 {% endif %}
-{% endfor %}
+{%- endfor %}
 {% endfor %}
 }
 

--- a/icinga2-ansible-add-hosts/templates/object_logic.j2
+++ b/icinga2-ansible-add-hosts/templates/object_logic.j2
@@ -5,6 +5,15 @@ object Host "{{ hostvars[item]['ansible_fqdn'] }}" {
   address = "{{ hostvars[item]['ansible_default_ipv4']['address'] }}"
   vars.os = "{{ hostvars[item]['ansible_system'] }}"
   vars.os_family = "{{ hostvars[item]['ansible_os_family'] }}"
+{% if hostvars[item]['ansible_local'] is mapping %}
+{% for key,value in hostvars[item]['ansible_local'].iteritems() %}
+{% if value is mapping %}
+{% for entrykey,entryvalue in value.iteritems() %}
+  vars.{{ entrykey }} = "{{ entryvalue }}"
+{% endfor %}
+{% endif %}
+{% endfor %}
+{% endif %}
 
   # Here Goes Vars and check_command
 {% for key,value in host_attributes.iteritems() %}

--- a/icinga2-ansible-classic-ui/defaults/main.yml
+++ b/icinga2-ansible-classic-ui/defaults/main.yml
@@ -1,2 +1,4 @@
 ---
 # defaults file for icinga2-ansible-classic-ui
+
+icinga2_classic_ui_passwd: "none"

--- a/icinga2-ansible-classic-ui/vars/main.yml
+++ b/icinga2-ansible-classic-ui/vars/main.yml
@@ -1,8 +1,6 @@
 ---
 # vars file for icinga2-ansible-classic-ui
 
-icinga2_classic_ui_passwd: "none"
-
 # Vars for Debian OS Family
 icinga2_classic_ui_pkg:
  - { package: "icinga2-classicui" }

--- a/icinga2-ansible-classic-ui/vars/main.yml
+++ b/icinga2-ansible-classic-ui/vars/main.yml
@@ -8,7 +8,7 @@ icinga2_classic_ui_pkg:
  - { package: "icinga2-classicui" }
  - { package: "python-passlib" }
 
-htpasswd_deb: "/etc/icinga2/classicui/htpasswd.users"
+htpasswd_deb: "/etc/icinga2-classicui/htpasswd.users"
 
 # Vars for RH OS Family
 icinga2_classic_ui_rpm:

--- a/icinga2-ansible-no-ui/defaults/main.yml
+++ b/icinga2-ansible-no-ui/defaults/main.yml
@@ -1,2 +1,7 @@
 ---
 # defaults file for icinga2-ansible-no-ui
+
+check_commands:
+  check_nrpe:
+    -H: "$address$"
+    -c: "$remote_nrpe_command$"

--- a/icinga2-ansible-no-ui/vars/main.yml
+++ b/icinga2-ansible-no-ui/vars/main.yml
@@ -37,7 +37,3 @@ icinga2_conf_global:
  - { directive: 'include "features-enabled/*.conf"' }
  - { directive: 'include_recursive "conf.d"' }
 
-check_commands:
-  check_nrpe:
-    -H: "$address$"
-    -c: "$remote_nrpe_command$"


### PR DESCRIPTION
Hi Valentino, a tiny character diff and the missing hosts directory were the showstoppers for me when I tried to install the classic UI on Debian Wheezy. 
Moreover I changed the object_logic.j2 template so that yaml dictionaries in host_vars will be translated into icinga2 dictionaries which can be used as object attributes.
In addition ansible_local facts will be translated into hostvars.

HTH
      Patricia
