### PR TITLE
improved debian support, allow commands from dict, dynamic plugin path

### DIFF
--- a/icinga2-nrpe-agent/README.md
+++ b/icinga2-nrpe-agent/README.md
@@ -42,6 +42,23 @@ Example Playbook
 
 ```
 
+It's possible to use a dict for **nrpe_configuration** instead of a plain text block:
+
+```yaml
+    nrpe_configuration: 
+      log_facility: daemon
+      debug: 0
+      pid_file: /var/run/nagios/nrpe.pid
+      server_port: 5666
+      server_address: "{{ ansible_default_ipv4.address }}"
+      nrpe_user: nagios
+      nrpe_group: nagios
+      dont_blame_nrpe: 0
+      allow_bash_command_substitution: 0
+      command_timeout: 60
+      connection_timeout: 150
+```
+
 A more flexible and advanced configuration of check commands can be done by:
 
 ```yaml

--- a/icinga2-nrpe-agent/README.md
+++ b/icinga2-nrpe-agent/README.md
@@ -33,14 +33,53 @@ Example Playbook
        command_timeout=60
        connection_timeout=150
      nrpe_check_commands: |
-       command[check_load]={{ nrpe_agent_plugins_x86_64 }}/check_load -w 15,10,8 -c 30,25,15
-       command[check_ssh]={{ nrpe_agent_plugins_x86_64 }}/check_ssh -H {{ ansible_eth0.ipv4.address }} -p {{ ansible_port }}
-       command[check_procs]={{ nrpe_agent_plugins_x86_64 }}/check_procs -w 300 -c 500
-       command[check_disk]={{ nrpe_agent_plugins_x86_64 }}/check_disk -w 15% -c 10% -p / -p /home -p /tmp
-       command[check_disk]={{ nrpe_agent_plugins_x86_64 }}/check_mem_ng
+       command[check_load]={{ nrpe_agent_plugins_path }}/check_load -w 15,10,8 -c 30,25,15
+       command[check_ssh]={{ nrpe_agent_plugins_path }}/check_ssh -H {{ ansible_eth0.ipv4.address }} -p {{ ansible_port }}
+       command[check_procs]={{ nrpe_agent_plugins_path }}/check_procs -w 300 -c 500
+       command[check_disk]={{ nrpe_agent_plugins_path }}/check_disk -w 15% -c 10% -p / -p /home -p /tmp
+       command[check_mem_ng]={{ nrpe_agent_plugins_path }}/check_mem_ng
      tags: nrpe-agent
 
 ```
+
+A more flexible and advanced configuration of check commands can be done by:
+
+```yaml
+    nrpe_check_commands:
+      check_variant1:
+        path: "/my/path/to/plugins/"
+        script: "my_check_script"
+        args: "-get -some -data"
+```
+
+If you have the scripts located at the plugin directory, you can omit the path:
+
+```yaml
+      check_variant2:
+        script: "my_check_script"
+        args: "-get -some -data"
+
+```
+
+Often the name for the check is the same as the script filename, so you can omit that too:
+
+```yaml
+      check_variant3:
+        args: "-get -some -data"
+
+```
+
+and if you done need any additional settings, you simply use the shorthand version:
+
+```yaml
+    nrpe_check_commands:
+      check_load: "-w 15,10,5 -c 30,25,20"
+      check_disk: "-w 20% -c 10% -p /"
+      check_ssh: "-H {{ ansible_eth0.ipv4.address }}"
+      check_procs: "-w 300 -c 500"
+      check_mem_ng:
+```
+
 
 Role Variables
 --------------
@@ -56,3 +95,5 @@ Author Information
 ------------------
 
 Valentino Gagliardi - Icinga Dev Team
+Martin Verges
+

--- a/icinga2-nrpe-agent/defaults/main.yml
+++ b/icinga2-nrpe-agent/defaults/main.yml
@@ -19,14 +19,16 @@ nrpe_agent_config: "/etc/nagios/nrpe.cfg"
 # A list of allowed hosts for Nrpe agent
 nrpe_allowed_hosts: "127.0.0.1,192.168.0.1"
 
-# Plugins path for RH and other x86_64
+# Plugins path
+nrpe_agent_plugins_x86_32: "/usr/lib/nagios/plugins"
 nrpe_agent_plugins_x86_64: "/usr/lib64/nagios/plugins"
 
 nrpe_agent_check_mem: "https://raw.githubusercontent.com/zwindler/check_mem_ng/master/check_mem_ng.sh"
 
+nrpe_server_group_name: "monitoring_servers"
+
 # Sample NRPE check commands
 nrpe_check_commands:
-  check_load:
-    check_load: "-w 15,10,5 -c 30,25,20"
-  check_disk:
-    check_disk: "-w 20% -c 10% -p /"
+  check_load: "-w 15,10,5 -c 30,25,20"
+  check_disk: "-w 20% -c 10% -p /"
+

--- a/icinga2-nrpe-agent/tasks/icinga2_nrpe_agent_Debian.yml
+++ b/icinga2-nrpe-agent/tasks/icinga2_nrpe_agent_Debian.yml
@@ -1,12 +1,18 @@
 ---
 - name: Install Nrpe and Plugins
-  apt: pkg={{ item.package }} 
-       state=latest
-       update_cache=yes
-       install_recommends=no
+  apt: 
+    name: "{{ item.package }}"
+    state: latest
+    install_recommends: no
+    default_release: "{{ item.release | default(omit) }}"
   with_items: "{{ nrpe_agent_Debian }}"
   tags:
    - nrpe_agent_install
+
+- name: Install Check_Mem_Ng on Debian
+  get_url: url={{ nrpe_agent_check_mem }}
+           dest={{ nrpe_agent_plugins_path }}/check_mem_ng
+           mode=0755
 
 - name: Copy Nrpe Configuration
   template: src=nrpe.cfg.j2

--- a/icinga2-nrpe-agent/tasks/locate_plugins.yml
+++ b/icinga2-nrpe-agent/tasks/locate_plugins.yml
@@ -1,0 +1,24 @@
+---
+- name: "Check for x86_64 plugin directory"
+  stat:
+    path: "{{ nrpe_agent_plugins_x86_64 }}"
+  register: plugins_path
+
+- set_fact:
+    nrpe_agent_plugins_path: "{{ nrpe_agent_plugins_x86_64 }}"
+  when: plugins_path.stat.isdir is defined and plugins_path.stat.readable == True
+    
+- name: "Check for x86_32 plugin directory"
+  stat:
+    path: "{{ nrpe_agent_plugins_x86_32 }}"
+  register: plugins_path
+  when: nrpe_agent_plugins_path is undefined
+
+- set_fact:
+    nrpe_agent_plugins_path: "{{ nrpe_agent_plugins_x86_32 }}"
+  when: plugins_path.stat.isdir is defined and plugins_path.stat.readable == True
+
+- fail: 
+    msg: "Unable to find the correct plugins path. Please check your nrpe_agent_plugins_x86_64 and nrpe_agent_plugins_x86_32 values."
+  when: nrpe_agent_plugins_path is undefined
+

--- a/icinga2-nrpe-agent/tasks/main.yml
+++ b/icinga2-nrpe-agent/tasks/main.yml
@@ -1,14 +1,17 @@
 ---
 # tasks file for icinga2-nrpe-agent
 
+- include: locate_plugins.yml
+
 - include: icinga2_nrpe_agent_RedHat.yml
-  when: ansible_os_family == 'RedHat' and 'monitoring_servers' not in group_names
+  when: ansible_os_family == 'RedHat' and nrpe_server_group_name not in group_names
   # NRPE Agent will be installed on clients only
 
 - include: icinga2_nrpe_agent_Debian.yml
-  when: ansible_os_family == 'Debian' and 'monitoring_servers' not in group_names
+  when: ansible_os_family == 'Debian' and nrpe_server_group_name not in group_names
   # NRPE Agent will be installed on clients only
 
 - include: icinga2_nrpe_agent_Gentoo.yml
-  when: ansible_os_family == 'Gentoo' and 'monitoring_servers' not in group_names
+  when: ansible_os_family == 'Gentoo' and nrpe_server_group_name not in group_names
   # NRPE Agent will be installed on clients only
+

--- a/icinga2-nrpe-agent/templates/nrpe.cfg.j2
+++ b/icinga2-nrpe-agent/templates/nrpe.cfg.j2
@@ -13,4 +13,15 @@ nrpe_user=nagios
 nrpe_group=nagios
 {% endif %}
 
+{% if nrpe_check_commands is mapping %}
+{% for key, value in nrpe_check_commands.iteritems() %}
+{% if value is mapping %}
+command[{{ key }}]={{ value.path | default(nrpe_agent_plugins_path) }}/{{ value.script | default(key) }} {{ value.args|default("") }}
+{% else %}
+command[{{ key }}]={{ nrpe_agent_plugins_path }}/{{ key }} {{ value }}
+{% endif %}
+{% endfor %}
+{% else %}
 {{ nrpe_check_commands }}
+{% endif %}
+

--- a/icinga2-nrpe-agent/templates/nrpe.cfg.j2
+++ b/icinga2-nrpe-agent/templates/nrpe.cfg.j2
@@ -2,7 +2,13 @@
 
 allowed_hosts={{ nrpe_allowed_hosts }}
 
+{% if nrpe_configuration is mapping %}
+{% for key, value in nrpe_configuration.iteritems() %}
+{{ key }}={{ value }}
+{% endfor %}
+{% else %}
 {{ nrpe_configuration }}
+{% endif %}
 
 {% if ansible_os_family == 'RedHat' %}
 nrpe_user=nrpe


### PR DESCRIPTION
Hello,

I had some trouble with your role on debian, so I updated some stuff that might help other people too.

- Debian has no **lib64** directory, so I added a second one and detect the correct one for later use with **nrpe_agent_plugins_path**. 
- **nrpe_check_commands** can now be added as a dict as it where documented in defaults/main.yml before but not possible
- **nrpe_server_group_name** allows to provide a custom name for monitoring server group
- **nrpe_configuration** now can be provided as a dict var

Feel free to provide me feedback or merge if it is ok for you

Best regards
Martin