### PR TITLE
Add support for Ubuntu 18.04

### DIFF
--- a/icinga2-ansible-web2-ui/tasks/icinga2_web2_ui_Debian_install.yml
+++ b/icinga2-ansible-web2-ui/tasks/icinga2_web2_ui_Debian_install.yml
@@ -5,13 +5,23 @@
 
 - name: Install PHP requirements
   apt:
-    name: "{{ item}}"
+    name: "{{ item }}"
     state: present
   with_items:
-    - php7.0
-    - libapache2-mod-php7.0
+    - php
     - php-gd
+    - libapache2-mod-php
 
+- name: Get PHP version
+  command: php --version
+  register: php_version
+  changed_when: false
+
+- name: Set PHP version
+  set_fact: php_version="{{ php_version.stdout_lines[0] | regex_replace('^PHP (\d\.\d).*$','\\1') }}"
+
+- name: Enable PHP apache module
+  apache2_module: name="php{{ php_version }}""
 
 - name: Find out timezone
   slurp:
@@ -20,7 +30,7 @@
 
 - name: Timezone in php.ini
   lineinfile:
-    path: /etc/php/7.0/apache2/php.ini
+    path: '/etc/php/{{ php_version }}/apache2/php.ini'
     regexp: '^;?date.timezone ='
     line: 'date.timezone = "{{ etc_timezone["content"] | b64decode | regex_replace("\n") }}"'
   notify: restart apache2


### PR DESCRIPTION
Ubuntu 18.04 comes with PHP 7.2 instead of 7.0.