### PR TITLE
Remove Debmon key and repository

### DIFF
--- a/icinga2-ansible-no-ui/tasks/icinga2_Debian_install.yml
+++ b/icinga2-ansible-no-ui/tasks/icinga2_Debian_install.yml
@@ -8,13 +8,11 @@
     url: "{{ icinga2_key }}"
     state: present
 
-  # Debian packages require additional packages which are provided by the
-  # Debian Monitoring Project repository
-  #- name: Get Debmon Apt Key for Debian OS family (Debian)
-  #apt_key:
-  #  id: DC0EE15A29D662D2
-  #  url: "{{ icinga2_debmon_key }}"
-  #  state: present
+  # Debmon has been shut down and is not required any more
+- name: Remove Debmon Apt Key for Debian OS family (Debian)
+  apt_key:
+    id: DC0EE15A29D662D2
+    state: absent
 
 - name: Get Icinga2 Apt Repos for Debian OS family
   apt_repository: repo='{{ item.repo }}'
@@ -22,12 +20,11 @@
                   state=present
   with_items: "{{ icinga2_deb_repos }}"
 
-  # Debian packages require additional packages which are provided by the
-  # Debian Monitoring Project repository
-- name: Get Debmon Apt Repo for Debian OS family (Debian)
+  # Debmon has been shut down and is not required any more
+- name: Remove Debmon Apt Repo for Debian OS family (Debian)
   apt_repository: repo='{{ icinga2_debmon_repo }}'
                   update_cache=yes
-                  state=present
+                  state=absent
 
 - name: Install Icinga2 on Debian OS family
   apt: pkg={{ item }}


### PR DESCRIPTION
Debmon has been shut down and is not required any more.