### PR TITLE
change Apt repos (#88)

### DIFF
--- a/icinga2-ansible-no-ui/defaults/main.yml
+++ b/icinga2-ansible-no-ui/defaults/main.yml
@@ -5,8 +5,8 @@ icinga2_key: "https://packages.icinga.org/icinga.key"
 # icinga2_debmon_key: "https://debmon.org/debmon/repo.key"
 
 icinga2_deb_repos:
- - { repo: "deb https://packages.icinga.org/{{ ansible_distribution|lower }} icinga-{{ ansible_distribution_release }} main" }
- - { repo: "deb-src https://packages.icinga.org/{{ ansible_distribution|lower }} icinga-{{ ansible_distribution_release }} main" }
+ - { repo: "deb https://packages.icinga.com/{{ ansible_distribution|lower }} icinga-{{ ansible_distribution_release }} main" }
+ - { repo: "deb-src https://packages.icinga.com/{{ ansible_distribution|lower }} icinga-{{ ansible_distribution_release }} main" }
 icinga2_debmon_repo: "deb http://debmon.org/debmon debmon-{{ ansible_distribution_release }} main"
 
 icinga2_pkg:

--- a/icinga2-ansible-no-ui/tasks/icinga2_Debian_install.yml
+++ b/icinga2-ansible-no-ui/tasks/icinga2_Debian_install.yml
@@ -14,6 +14,13 @@
     id: DC0EE15A29D662D2
     state: absent
 
+  # The Apt repo now lives on packages.icinga.com
+- name: Remove old Apt repos
+  apt_repository: repo='{{ item.repo|replace("packages.icinga.com", "packages.icinga.org") }}'
+                  update_cache=no
+                  state=absent
+  with_items: "{{ icinga2_deb_repos }}"
+
 - name: Get Icinga2 Apt Repos for Debian OS family
   apt_repository: repo='{{ item.repo }}'
                   update_cache=yes

--- a/icinga2-ansible-no-ui/tasks/icinga2_Ubuntu_install.yml
+++ b/icinga2-ansible-no-ui/tasks/icinga2_Ubuntu_install.yml
@@ -10,6 +10,13 @@
     url: "{{ icinga2_key }}"
     state: present
 
+- name: Remove old Apt Repos
+  apt_repository:
+    repo: "{{ item.repo|replace('packages.icinga.com', 'packages.icinga.org') }}"
+    update_cache: no
+    state: absent
+  with_items: "{{ icinga2_deb_repos }}"
+
 - name: Get Icinga2 Apt Repos for Debian OS family
   apt_repository:
     repo: "{{ item.repo }}"


### PR DESCRIPTION
packages.icinga.org has an invalid TLS certificate, so apt-get update
fails loudly. This changes the repo URL to packages.icinga.com (which
has a valid certificate, and to which packages.icinga.org also
redirects).

This fixes #88.