### PR TITLE
Fixing URL for icinga.com (not .org)

### DIFF
--- a/icinga2-ansible-no-ui/defaults/main.yml
+++ b/icinga2-ansible-no-ui/defaults/main.yml
@@ -1,8 +1,8 @@
 ---
 # defaults file for icinga2-ansible-no-ui
 
-icinga2_key: "https://packages.icinga.org/icinga.key"
-# icinga2_debmon_key: "https://debmon.org/debmon/repo.key"
+icinga2_key: "https://packages.icinga.com/icinga.key"
+# icinga2_debmon_key: "https://debmon.com/debmon/repo.key"
 
 icinga2_deb_repos:
  - { repo: "deb https://packages.icinga.com/{{ ansible_distribution|lower }} icinga-{{ ansible_distribution_release }} main" }
@@ -16,8 +16,8 @@ icinga2_pkg:
  - nagios-nrpe-plugin
 
 icinga2_use_public_yum_repo: True
-icinga2_url_yum: "https://packages.icinga.org/epel/ICINGA-release.repo"
-icinga2_url_yum_fedora: "https://packages.icinga.org/fedora/ICINGA-release.repo"
+icinga2_url_yum: "https://packages.icinga.com/epel/ICINGA-release.repo"
+icinga2_url_yum_fedora: "https://packages.icinga.com/fedora/ICINGA-release.repo"
 icinga2_repo_yum: "/etc/yum.repos.d/ICINGA-release.repo"
 
 icinga2_yum:


### PR DESCRIPTION
apt-key gave error as the site's canonical hostname is now packages.icinga.com (and the certificate is for this URL). Changed URL in the config to fix.