### PR TITLE
Changes 'iteritems()' to 'items() | list' (python3 support)

### DIFF
--- a/icinga2-ansible-add-hosts/templates/object_logic.j2
+++ b/icinga2-ansible-add-hosts/templates/object_logic.j2
@@ -11,7 +11,7 @@ object Host "{{ hostvars[item]['ansible_fqdn'] }}" {
   {{ host_attributes }}
 
   {% if 'icinga_host_attributes' in hostvars[item] %}
-    {% for attribute, value in hostvars[item].icinga_host_attributes.iteritems() %}
+    {% for attribute, value in hostvars[item].icinga_host_attributes.items() | list %}
     {{ attribute }} = {{ value }}
     {% endfor %}
   {% endif %}

--- a/icinga2-ansible-no-ui/templates/icinga2_check_commands.j2
+++ b/icinga2-ansible-no-ui/templates/icinga2_check_commands.j2
@@ -1,6 +1,6 @@
 # {{ ansible_managed }}
 
-{% for key,value in check_commands.iteritems() %}
+{% for key,value in check_commands.items() | list %}
 object CheckCommand "{{ key }}" {
   import "plugin-check-command"
 


### PR DESCRIPTION
 because it is supported by python2 and python3

With this change it should be possible to use python2 or python3 for this playbooks. Python3 does not have 'iteritems()' anymore