### PR TITLE
fix icinga2_web2_db privileges

### DIFF
--- a/icinga2-ansible-web2-ui/tasks/icinga2_web2_ui_Debian_install.yml
+++ b/icinga2-ansible-web2-ui/tasks/icinga2_web2_ui_Debian_install.yml
@@ -94,7 +94,7 @@
     name: "{{ icinga2_web2_db_user }}"
     password: "{{ icinga2_web2_db_pass }}"
     state: present
-    priv: "{{ icinga2_web2_db }}.*:GRANT,INSERT,SELECT,UPDATE,DELETE,DROP,CREATE VIEW,INDEX,EXECUTE"
+    priv: "{{ icinga2_web2_db }}.*:ALL"
 
 - name: Import the Web Schema on Icinga Web Database (only once)
   mysql_db:


### PR DESCRIPTION
In issue https://github.com/Icinga/ansible-playbooks/issues/72 , there are two similar comments mentioning icingaweb requires additional privileges.   

> Same problem here.GRANT ALL ON icingaweb.* TO icingaweb@localhost or modifying the privileges in icinga2_web2_ui_Debian_install.yml solves the problem.

And I also encountered this today.